### PR TITLE
fix: resolve duplicate @Order annotations in data loaders

### DIFF
--- a/src/main/java/com/movie/movie_backend/config/StatusUpdater.java
+++ b/src/main/java/com/movie/movie_backend/config/StatusUpdater.java
@@ -31,7 +31,7 @@
 //     private String kmdbApiKey;
 //
 //     @Bean
-//     @Order(7)  // 태그 매핑 다음에 실행
+//     @Order(8)  // 태그 매핑 다음에 실행
 //     public CommandLineRunner updateMovieStatusFromKmdb() {
 //         return args -> {
 //             log.info("=== KMDb status 동기화 시작 ===");

--- a/src/main/java/com/movie/movie_backend/config/TagMapper.java
+++ b/src/main/java/com/movie/movie_backend/config/TagMapper.java
@@ -16,7 +16,7 @@
 //     private final TagDataService tagDataService;
 //
 //     @Bean
-//     @Order(6)  // KMDb ID 매핑 다음에 실행
+//     @Order(7)  // KMDb ID 매핑 다음에 실행
 //     public CommandLineRunner autoMapMovieDetailTags() {
 //         return args -> {
 //             log.info("=== TagDataService.setupTagData() 자동 실행 ===");


### PR DESCRIPTION
- TagMapper: change @Order(6) → @Order(7)
- StatusUpdater: change @Order(7) → @Order(8)
- organize data loading sequence: MovieList → BoxOffice → Description → Stillcut → Kmdb → Tmdb → Tag → Status